### PR TITLE
Add `all` option to satellite arg in CLI tool and general housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,174 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.DS_Store
-.ipynb_checkpoints/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/landsat_pass.py
+++ b/landsat_pass.py
@@ -138,13 +138,12 @@ def next_landsat_pass(lat: float, lon: float) -> None:
                     [direction.capitalize(), "N/A", "N/A", "N/A", "No data found."]
                 )
 
-        print(
-            tabulate(
-                table_data,
-                headers=["Direction", "Path", "Row", "Mission", "Next Passes"],
-                tablefmt="grid"
+        return {"next_collect_info": tabulate(
+            table_data,
+            headers=["Direction", "Path", "Row", "Mission", "Next Passes"],
+            tablefmt="grid"
             )
-        )
+            }
 
     except Exception as error:
         logging.exception(f"An unexpected error occurred: {error}")
@@ -173,4 +172,6 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
-    next_landsat_pass(args.lat, args.lon)
+    result = next_landsat_pass(args.lat, args.lon)
+    if result:
+        print(result.get("next_collect_info", "No collection info available."))

--- a/next_pass.py
+++ b/next_pass.py
@@ -26,7 +26,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="Bounding box coordinates (SNWE order). A point has equal SN and EW."
     )
     parser.add_argument(
-        "-s", "--satellite", default="all",
+        "-s", "--sat", default="all",
         choices=["sentinel-1", "sentinel-2", "landsat", "all"],
         help="Satellite mission. Default is all."
     )

--- a/next_pass.py
+++ b/next_pass.py
@@ -89,7 +89,7 @@ def find_next_overpass(args) -> dict:
     else:
         geometry = box(lon_min, lat_min, lon_max, lat_max)
 
-    if args.satellite == "all":
+    if args.sat == "all":
         LOGGER.info("Fetching Sentinel-1 data...")
         sentinel1 = next_sentinel_pass(create_s1_collection_plan, geometry)
 
@@ -105,15 +105,15 @@ def find_next_overpass(args) -> dict:
             "landsat": landsat,
         }
 
-    if args.satellite == "sentinel-1":
+    if args.sat == "sentinel-1":
         LOGGER.info("Fetching Sentinel-1 data...")
         return next_sentinel_pass(create_s1_collection_plan, geometry)
 
-    if args.satellite == "sentinel-2":
+    if args.sat == "sentinel-2":
         LOGGER.info("Fetching Sentinel-2 data...")
         return next_sentinel_pass(create_s2_collection_plan, geometry)
 
-    if args.satellite == "landsat":
+    if args.sat == "landsat":
         LOGGER.info("Fetching Landsat data...")
         return next_landsat_pass(lat_min, lon_min)
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+
 import geopandas as gpd
 from shapely.geometry import Point, box
 from tabulate import tabulate
+
 from landsat_pass import next_landsat_pass
 from s1_collection import create_s1_collection_plan
 from s2_collection import create_s2_collection_plan
-from utils import (create_polygon_from_kml,
-                   find_intersecting_collects, bbox_type)
+from utils import (bbox_type,
+                   create_polygon_from_kml,
+                   find_intersecting_collects)
 
 LOGGER = logging.getLogger("next_pass")
 
@@ -16,26 +19,46 @@ LOGGER = logging.getLogger("next_pass")
 def create_parser():
     parser = argparse.ArgumentParser(
         description="Find next satellite overpass date.")
-    parser.add_argument("-b", "--bbox", required=True, type=float, nargs=4,
-                        metavar=("lat_min", "lat_max", "lon_min", "lon_max"),
-                        help=("Bounding box coordinates (SNWE order)."
-                              "A single point can be given as "
-                              "equal values for SN and EW"))
-    parser.add_argument("-s", "--satellite", required=True,
-                        choices=["sentinel-1", "sentinel-2", "landsat"],
-                        help="Satellite mission")
-    parser.add_argument("-f", "--aoi-file", type=str,
-                        help="Path to KML file for AOI polygon")
-    parser.add_argument("-l", "--log_level", default="info",
-                        choices=["debug", "info", "warning", "error"],
-                        help="Set logging level")
+    parser.add_argument(
+        "-b",
+        "--bbox",
+        required=True,
+        type=float,
+        nargs=4,
+        metavar=("lat_min", "lat_max", "lon_min", "lon_max"),
+        help=(
+            "Bounding box coordinates (SNWE order)."
+            "A single point can be given as "
+            "equal values for SN and EW"
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--satellite",
+        required=True,
+        choices=["sentinel-1", "sentinel-2", "landsat"],
+        help="Satellite mission",
+    )
+    parser.add_argument(
+        "-f", "--aoi-file", type=str, help="Path to KML file for AOI polygon"
+    )
+    parser.add_argument(
+        "-l",
+        "--log_level",
+        default="info",
+        choices=["debug", "info", "warning", "error"],
+        help="Set logging level",
+    )
     return parser
 
 
 def format_collects(gdf):
-    table = [(idx + 1, row.begin_date.strftime("%Y-%m-%d %H:%M:%S"),
-              row.orbit_relative)
-             for idx, row in gdf.iterrows()]
+    table = [
+        (idx + 1,
+         row.begin_date.strftime("%Y-%m-%d %H:%M:%S"),
+         row.orbit_relative)
+        for idx, row in gdf.iterrows()
+    ]
     headers = ["#", "Collection Date & Time", "Relative Orbit"]
     return tabulate(table, headers, tablefmt="grid")
 
@@ -50,10 +73,7 @@ def find_next_overpass(args):
         geometry = box(lon_min, lat_min, lon_max, lat_max)
 
     # Initialize the return dictionary with default values
-    result = {
-        "next_collect_info": None,
-        "next_collect_geometry": None
-    }
+    result = {"next_collect_info": None, "next_collect_geometry": None}
     if args.satellite == "sentinel-1":
         LOGGER.info("Processing Sentinel-1 data...")
         gdf = gpd.read_file(create_s1_collection_plan())
@@ -61,10 +81,14 @@ def find_next_overpass(args):
 
         if not collects.empty:
             result["next_collect_info"] = format_collects(collects)
-            result["next_collect_geometry"] = collects.geometry.tolist()  # Convert geometries to list
+            result["next_collect_geometry"] = (
+                collects.geometry.tolist()
+            )
         else:
-            result["next_collect_info"] = f"No scheduled collect before {gdf['end_date'].max().date()}."
-            result["next_collect_geometry"] = None  # Set to None if no collections
+            result["next_collect_info"] = (
+                f"No scheduled collect before {gdf['end_date'].max().date()}."
+            )
+            result["next_collect_geometry"] = None
         return result
 
     elif args.satellite == "sentinel-2":
@@ -74,21 +98,32 @@ def find_next_overpass(args):
 
         if not collects.empty:
             result["next_collect_info"] = format_collects(collects)
-            result["next_collect_geometry"] = collects.geometry.tolist()  # Convert geometries to list
+            result["next_collect_geometry"] = (
+                collects.geometry.tolist()
+            )
         else:
-            result["next_collect_info"] = f"No scheduled collect before {gdf['end_date'].max().date()}."
-            result["next_collect_geometry"] = None  # Set to None if no collections
+            result["next_collect_info"] = (
+                f"No scheduled collect before {gdf['end_date'].max().date()}."
+            )
+            result["next_collect_geometry"] = None
         return result
 
     elif args.satellite == "landsat":
         LOGGER.info("Fetching Landsat data...")
         return next_landsat_pass(lat_min, lon_min)
 
+
 if __name__ == "__main__":
     args = create_parser().parse_args()
-    logging.basicConfig(level=args.log_level.upper(),
-                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    if args.satellite.lower() == 'landsat':
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    if args.satellite.lower() == "landsat":
         find_next_overpass(args)
     else:
-        print(find_next_overpass(args).get("next_collect_info", "No collection info available"))
+        print(
+            find_next_overpass(args).get(
+                "next_collect_info", "No collection info available"
+            )
+        )

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 
 LOGGER = logging.getLogger('acquisition_utils')
 
+
 def scrape_esa_download_urls(url: str, class_: str) -> List[str]:
     """Scrape ESA website for KML download URLs."""
     response = requests.get(url)


### PR DESCRIPTION
This PR changes the `--satellite/-s` argument to default to `all` when not given.

The changes include:
- styling and clean up of both `next_pass.py` and `landsat_pass.py`
- Update `landsat_pass.py` to use `requests` package.
- Change `landsat_pass.py` output to a dictionary.
- Move the `sentinel-1/2` fetching method to a function and simplify the `find_next_overpass` function.
- Change the `-s/--satellite` argument from `required` to `optional` and `default=all`
- Change `--satellite` to `--sat`
- Update the `.gitignore` file with python standard