### PR TITLE
Compute AOI intersection percentages for Sentinel-1, Sentinel-2, and Landsat

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ mamba install -c conda-forge --yes --file requirements.txt
 Use "Run_next_pass.ipynb" 
 ```
 ```bash
-python next_pass.py -b 34 35 -119 -117 --sat sentinel-1
-python next_pass.py -b 34 35 -119 -117 --sat sentinel-2 -fp'../../data/KML/LA_National_Forest.kml'
-python next_pass.py -b 34 34 -119 -119 --sat landsat
+Point (lat/lon pair):
+  python next_pass.py -b 34.20 -118.17
+
+Bounding Box (SNWE):
+  python next_pass.py -b 34.15 34.25 -118.20 -118.15
+
+KML File:
+  python next_pass.py -b /path/to/file.kml
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ mamba install -c conda-forge --yes --file requirements.txt
 Use "Run_next_pass.ipynb" 
 ```
 ```bash
-python next_pass.py -bb 34 35 -119 -117 -sat sentinel-1
-python next_pass.py -bb 34 35 -119 -117 -sat sentinel-2 -fp'../../data/KML/LA_National_Forest.kml'
-python next_pass.py -bb 34 34 -119 -119 -sat landsat
+python next_pass.py -b 34 35 -119 -117 --sat sentinel-1
+python next_pass.py -b 34 35 -119 -117 --sat sentinel-2 -fp'../../data/KML/LA_National_Forest.kml'
+python next_pass.py -b 34 34 -119 -119 --sat landsat
 ```

--- a/landsat_pass.py
+++ b/landsat_pass.py
@@ -170,7 +170,7 @@ def next_landsat_pass(lat: float, lon: float, geometryAOI) -> None:
 
         return {"next_collect_info": tabulate(
             table_data,
-            headers=["Direction", "Path", "Row", "Mission", "Next Passes", "AOI % Coverage"],
+            headers=["Direction", "Path", "Row", "Mission", "Next Passes", "AOI % Overlap"],
             tablefmt="grid"
             ),
             "next_collect_geometry": geometry_data

--- a/landsat_pass.py
+++ b/landsat_pass.py
@@ -117,13 +117,16 @@ def find_next_landsat_pass(path: int, session: requests.Session, num_passes: int
     return next_passes
 
 
-def next_landsat_pass(lat: float, lon: float) -> None:
+def next_landsat_pass(lat: float, lon: float, geometryAOI) -> None:
     """
     Main function to retrieve and display the next Landsat passes for a given location.
 
     Args:
         lat (float): Latitude.
         lon (float): Longitude.
+        geometryAOI: Geometry of the area of interest used for computing intersection percentage.
+    Returns:
+        dict: Dictionary containing next Landsat passes information and geometries.
     """
     session = requests.Session()
 
@@ -139,6 +142,14 @@ def next_landsat_pass(lat: float, lon: float) -> None:
                     row = feature["row"]
                     geometry = feature.get("geometry")
                     polygon = arcgis_to_polygon(geometry)
+
+                    if polygon and polygon.is_valid and geometryAOI.is_valid:
+                        intersection = polygon.intersection(geometryAOI)
+                        intersection_pct = 100 * (intersection.area / geometryAOI.area)
+                        intersection_str = f"{intersection_pct:.1f}%"
+                    else:
+                        intersection_str = "N/A"
+
                     next_pass_dates = find_next_landsat_pass(path, session=session, num_passes=5)
                     for mission, dates in next_pass_dates.items():
                         row_data = [
@@ -146,19 +157,20 @@ def next_landsat_pass(lat: float, lon: float) -> None:
                             path,
                             row,
                             mission.capitalize(),
-                            ", ".join(dates) if dates else "No future passes found."
+                            ", ".join(dates) if dates else "No future passes found.",
+                            intersection_str
                         ]
                         table_data.append(row_data)
                         if polygon:
                             geometry_data.append(polygon)
             else:
                 table_data.append(
-                    [direction.capitalize(), "N/A", "N/A", "N/A", "No data found."]
+                    [direction.capitalize(), "N/A", "N/A", "N/A", "No data found.", "N/A"]
                 )
 
         return {"next_collect_info": tabulate(
             table_data,
-            headers=["Direction", "Path", "Row", "Mission", "Next Passes"],
+            headers=["Direction", "Path", "Row", "Mission", "Next Passes", "AOI % Coverage"],
             tablefmt="grid"
             ),
             "next_collect_geometry": geometry_data

--- a/next_pass.py
+++ b/next_pass.py
@@ -126,7 +126,7 @@ def find_next_overpass(args) -> dict:
 
     if args.sat == "landsat":
         LOGGER.info("Fetching Landsat data...")
-        landsat = next_landsat_pass(lat_min, lon_min)
+        landsat = next_landsat_pass(lat_min, lon_min, geometry)
         sentinel1 = []
         sentinel2 = []
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -110,7 +110,7 @@ def find_next_overpass(args) -> dict:
         sentinel2 = next_sentinel_pass(create_s2_collection_plan, geometry)
 
         LOGGER.info("Fetching Landsat data...")
-        landsat = next_landsat_pass(lat_min, lon_min)
+        landsat = next_landsat_pass(lat_min, lon_min, geometry)
 
     if args.sat == "sentinel-1":
         LOGGER.info("Fetching Sentinel-1 data...")


### PR DESCRIPTION
This PR adds functionality to calculate and display the percentage of spatial overlap between each satellite pass (relative orbit) and the user-defined AOI. The output tables for Sentinel-1, Sentinel-2, and Landsat now include an "AOI % Overlap" column for easier prioritization of relevant overpasses. Additional minor updates were made to README.md.

### Example Usage
Running ```python next_pass.py -b 20 25 -103 -100 -s sentinel-1``` on 06/09/2025.

### Example Output
```
=== SENTINEL-1 ===
+-----+--------------------------+------------------+-----------------+
|   # | Collection Date & Time   |   Relative Orbit |   AOI % Overlap |
+=====+==========================+==================+=================+
|   1 | 2025-06-17 12:40:05      |              114 |            80.6 |
+-----+--------------------------+------------------+-----------------+
|   2 | 2025-06-15 00:47:01      |               78 |            65.4 |
+-----+--------------------------+------------------+-----------------+
|   3 | 2025-06-20 00:55:46      |              151 |            49.7 |
+-----+--------------------------+------------------+-----------------+
|   4 | 2025-06-12 12:32:26      |               41 |            27.2 |
+-----+--------------------------+------------------+-----------------+
|   5 | 2025-06-24 12:32:26      |               41 |            27.2 |
+-----+--------------------------+------------------+-----------------+
|   6 | 2025-06-10 00:38:52      |                5 |             3   |
+-----+--------------------------+------------------+-----------------+
|   7 | 2025-06-22 00:38:52      |                5 |             3   |
+-----+--------------------------+------------------+-----------------+
```

In this case, Relative Orbit 114 on 06/17/2025 will cover 80.6% of this AOI.