### PR TITLE
Add programmatic entry point to next_pass

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,3 @@ dependencies:
   - lxml
   - rasterio
   - tabulate
-  - csv

--- a/next_pass.py
+++ b/next_pass.py
@@ -200,10 +200,24 @@ def send_email(subject, body, attachment=None):
              )
     return
 
-def main():
-    """Main entry point."""
-    args = create_parser().parse_args()
+def run_next_pass(bbox, satellites='all', number_of_dates=5):
+    
+    parser = create_parser()
+    cli_args = ["-b", *map(str, bbox), "-s", satellites, "-n", str(number_of_dates)]
+    args = parser.parse_args(cli_args)
+    timestamp_dir = main(args)
+    
+    return timestamp_dir
 
+def main(cli_args=None):
+    """Main entry point."""
+    if isinstance(cli_args, argparse.Namespace):
+        args = cli_args
+    elif cli_args is None:
+        args = create_parser().parse_args()
+    else:
+        args = create_parser().parse_args(cli_args)
+        
     logging.basicConfig(
         level=args.log_level.upper(),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -244,6 +258,7 @@ def main():
                         args.products)
         export_opera_products(results_opera, timestamp_dir)
         make_opera_granule_map(results_opera, args.bbox, timestamp_dir)
+        return timestamp_dir
 
     if args.email:
         overpasses_map = timestamp_dir / "satellite_overpasses_map.html"

--- a/next_pass.py
+++ b/next_pass.py
@@ -177,6 +177,7 @@ def format_arg(bbox_arg):
     else:
         raise ValueError("Argument must be a list of 1, 2, or 4 strings.")
 
+
 def send_email(subject, body, attachment=None):
     """
     Send an email with the next_pass information.
@@ -200,41 +201,28 @@ def send_email(subject, body, attachment=None):
              )
     return
 
+
 def run_next_pass(
     bbox,
     number_of_dates=5,
     date=None,
-    short_name=None,
-    layer_name=None,
-    mode="flood",
-    output_dir=Path("output")
+    functionality="opera_search"
     ):
     """
     Programmatic entry point for next_pass. Wraps main() and builds CLI-style args.
-
     Args:
         bbox (list[float]): [south, north, west, east]
-        satellites (str): Satellite string, default "all"
         number_of_dates (int): Number of recent dates to consider
         date (str or None): Optional date string (YYYY-MM-DD)
-        short_name (str or None): Optional short name to filter OPERA products
-        layer_name (str or None): Optional layer name (e.g. "WTR")
-        mode (str): Operation mode, e.g., "flood"
-        output_dir (Path): Directory to write output to
     """
     cli_args = [
         "-b", *map(str, bbox),
         "-n", str(number_of_dates),
-        "-m", mode,
-        "-o", str(output_dir)
+        "-f", functionality
     ]
 
     if date:
         cli_args += ["-d", date]
-    if short_name:
-        cli_args += ["-sn", short_name]
-    if layer_name:
-        cli_args += ["-l", layer_name]
 
     return main(cli_args)
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -226,6 +226,7 @@ def run_next_pass(
 
     return main(cli_args)
 
+
 def main(cli_args=None):
     """Main entry point."""
     if isinstance(cli_args, argparse.Namespace):
@@ -290,6 +291,7 @@ def main(cli_args=None):
         print('=========================================')
         print('Alert emailed to recipients.')
         print('=========================================')
+
 
 if __name__ == "__main__":
     main()

--- a/next_pass.py
+++ b/next_pass.py
@@ -214,6 +214,7 @@ def run_next_pass(
         bbox (list[float]): [south, north, west, east]
         number_of_dates (int): Number of recent dates to consider
         date (str or None): Optional date string (YYYY-MM-DD)
+        functionality (str): Functionality to run: 'overpasses', 'opera_search', or 'both'
     """
     cli_args = [
         "-b", *map(str, bbox),

--- a/next_pass.py
+++ b/next_pass.py
@@ -200,14 +200,43 @@ def send_email(subject, body, attachment=None):
              )
     return
 
-def run_next_pass(bbox, satellites='all', number_of_dates=5):
-    
-    parser = create_parser()
-    cli_args = ["-b", *map(str, bbox), "-s", satellites, "-n", str(number_of_dates)]
-    args = parser.parse_args(cli_args)
-    timestamp_dir = main(args)
-    
-    return timestamp_dir
+def run_next_pass(
+    bbox,
+    number_of_dates=5,
+    date=None,
+    short_name=None,
+    layer_name=None,
+    mode="flood",
+    output_dir=Path("output")
+    ):
+    """
+    Programmatic entry point for next_pass. Wraps main() and builds CLI-style args.
+
+    Args:
+        bbox (list[float]): [south, north, west, east]
+        satellites (str): Satellite string, default "all"
+        number_of_dates (int): Number of recent dates to consider
+        date (str or None): Optional date string (YYYY-MM-DD)
+        short_name (str or None): Optional short name to filter OPERA products
+        layer_name (str or None): Optional layer name (e.g. "WTR")
+        mode (str): Operation mode, e.g., "flood"
+        output_dir (Path): Directory to write output to
+    """
+    cli_args = [
+        "-b", *map(str, bbox),
+        "-n", str(number_of_dates),
+        "-m", mode,
+        "-o", str(output_dir)
+    ]
+
+    if date:
+        cli_args += ["-d", date]
+    if short_name:
+        cli_args += ["-sn", short_name]
+    if layer_name:
+        cli_args += ["-l", layer_name]
+
+    return main(cli_args)
 
 def main(cli_args=None):
     """Main entry point."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "next_pass"
+version = "0.1.0"
+description = "Tool to find upcoming satellite overpasses and OPERA product availability"
+authors = [
+    { name = "OPERA-Cal-Val" }
+]
+readme = ""
+requires-python = ">=3.7"
+dependencies = []  # Add any runtime dependencies here if needed
+license = {text = "MIT"}  # Update if using a different license
+classifiers = [
+    "Programming Language :: Python :: 3"
+]
+urls = { 
+    "Homepage" = "https://github.com/OPERA-Cal-Val/next_pass" 
+}
+
+[tool.setuptools]
+py-modules = [
+    "next_pass",
+    "collection_builder",
+    "landsat_pass",
+    "sentinel_pass",
+    "opera_products",
+    "plot_maps",
+    "utils"
+]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+setup(
+    name="next_pass",
+    version="0.1.0",
+    py_modules=["next_pass", "collection_builder", "landsat_pass", "sentinel_pass", "opera_products", "plot_maps", "utils"],
+    install_requires=[],
+    description="Tool to find upcoming satellite overpasses and OPERA product availability",
+    author="OPERA-Cal-Val",
+    url="https://github.com/cmspeed/next_pass",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,8 @@ setup(
     install_requires=[],
     description="Tool to find upcoming satellite overpasses and OPERA product availability",
     author="OPERA-Cal-Val",
-    url="https://github.com/cmspeed/next_pass",
+    url="https://github.com/OPERA-Cal-Val/next_pass",
     classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3"
     ],
 )


### PR DESCRIPTION
This PR adds a `run_next_pass()` function to `next_pass.py`, allowing the package to be called programmatically from other Python code. This function wraps the CLI interface by building an argument list and calling `next_pass.main()`, enabling integration with external workflows (e.g., `disasters`). No changes were made to the existing CLI behavior.

Additionally a `setup.py` and `pyproject.toml` is added for installation of `next_pass` into python environments via `pip install -e .`. This PR also removes the `csv` package from `environment.yml`, as it is part of Python's standard library. 