### PR TITLE
Restore `sys.stdout` and `sys.stderr` at exit to prevent downstream crashes

### DIFF
--- a/next_pass.py
+++ b/next_pass.py
@@ -400,6 +400,14 @@ def main(cli_args: Any = None):
         print("Alert emailed to recipients.")
         print("=========================================")
 
+    # Restore standard output and error
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+    
+    # Ensure the log file is closed
+    if not log.closed:
+        log.close()
+
     return timestamp_dir
 
 


### PR DESCRIPTION
Previously, `next_pass` overwrote the global `sys.stdout` and `sys.stderr` streams to duplicate terminal output to a log file, but did not restored them before exiting. This left downstream applications, such as the opera-disaster pipeline, with a broken `sys.stderr` stream, sometimes causing `sys.excepthook` crashes when multiprocessing workers attempted to print warnings during shutdown. This PR fixes the issue by explicitly restoring the global streams to their original states (`sys.__stdout__ `and `sys.__stderr__`) at the end of the script, allowing the downstream pipelines to exit cleanly and print errors properly.