### PR TITLE
Fix UTC-aware past/future routing for cloudiness API selection

### DIFF
--- a/utils/cloudiness.py
+++ b/utils/cloudiness.py
@@ -32,6 +32,14 @@ def chunks(seq, size):
         yield seq[i:i + size]
 
 
+def as_utc_datetime(dt_like: Union[str, datetime]) -> datetime:
+    """Normalize string/datetime input to a timezone-aware UTC datetime."""
+    dt = parse_datetime(dt_like) if isinstance(dt_like, str) else dt_like
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 class RateLimiter:
     def __init__(self, rate_per_sec):
         self.lock = threading.Lock()
@@ -487,12 +495,8 @@ def get_overpass_cloudiness(
     """
     try:
         # Normalize datetime
-        if isinstance(target_datetime, str):
-            target_dt = parse_datetime(target_datetime)
-        else:
-            target_dt = target_datetime
-
-        target_iso = target_dt.strftime("%Y-%m-%dT%H:%M")
+        target_dt_utc = as_utc_datetime(target_datetime)
+        target_iso = target_dt_utc.strftime("%Y-%m-%dT%H:%M")
 
         # Prepare polygon and sample points
         poly = shape(polygon_geojson)
@@ -510,10 +514,7 @@ def get_overpass_cloudiness(
         global hit_api_limit 
         cloudiness_values: List[float] = []
 
-        date_format = "%Y-%m-%dT%H:%M"
-        target_f = datetime.strptime(target_iso, date_format)
-
-        is_future = (target_f > datetime.now())
+        is_future = target_dt_utc > datetime.now(timezone.utc)
         batch_func = (
             get_cloudiness_at_points
             if is_future


### PR DESCRIPTION
## Summary
This PR fixes timezone handling in cloudiness routing so overpass times are always evaluated in UTC before deciding whether to query forecast or historical weather APIs.

## Problem
The previous logic converted `target_iso` to a naive datetime and compared it with `datetime.now()` in local system time. That can misclassify an overpass as future/past depending on the machine timezone.

## Example
Assume local machine timezone is America/Los_Angeles.
- Current local time: 2026-03-07 17:30 PST (which is 2026-03-08 01:30 UTC)
- Target overpass: `2026-03-08T01:00` (intended UTC)

Correct interpretation: target is in the past (30 minutes earlier in UTC), so historical API should be used.
Old behavior: treated target as naive local `2026-03-08 01:00` (PST), which appears in the future, so forecast API was incorrectly selected.

## Changes
- Added `as_utc_datetime(...)` helper in `utils/cloudiness.py` to normalize string/datetime input to timezone-aware UTC.
- Updated `get_overpass_cloudiness(...)` to:
  - format `target_iso` from UTC-normalized datetime
  - compare against `datetime.now(timezone.utc)`
  - route to forecast vs archive API based on UTC-aware comparison

## Validation
- `python -m compileall -q utils next_pass.py`

## Impact
Ensures consistent, timezone-correct API routing across environments and prevents incorrect cloudiness results caused by local timezone offsets.