### PR TITLE
Preserve platform in Sentinel cloudiness grouping

### DIFF
--- a/utils/sentinel_pass.py
+++ b/utils/sentinel_pass.py
@@ -205,16 +205,23 @@ def next_sentinel_pass(
         LOGGER.warning("The collection plan does not contain a 'platform' column.")
 
     collects = find_intersecting_collects(gdf, geometry)
-    collects = collects.drop_duplicates(subset=["begin_date", "orbit_relative"])
+    dedupe_cols = ["begin_date", "orbit_relative"]
+    if "platform" in collects.columns:
+        dedupe_cols.append("platform")
+    collects = collects.drop_duplicates(subset=dedupe_cols)
 
     if "platform" not in gdf.columns:
         LOGGER.warning("The collection plan does not contain a 'platform' column.")
 
     if not collects.empty:
         if arg_cloudiness:
+            groupby_cols = ["orbit_relative"]
+            if "platform" in collects.columns and collects["platform"].notna().any():
+                groupby_cols.append("platform")
+
             # Group collects by orbit, aggregate timestamps as list
             collects_grouped = (
-                collects.groupby("orbit_relative", sort=False)
+                collects.groupby(groupby_cols, sort=False)
                 .agg(
                     {
                         "begin_date": list,


### PR DESCRIPTION
## Summary
Fix Sentinel-1 cloudiness-mode grouping so S1A and S1C are not merged when they share the same relative orbit.

## Problem
In `next_sentinel_pass`, cloudiness-mode grouping used only `orbit_relative`, and dedupe ignored platform. That could collapse S1A and S1C records into one bucket, mixing dates/geometries/cloudiness outputs.

## Changes
- Updated deduplication to include `platform` when present.
- Updated cloudiness-mode grouping to use `[orbit_relative, platform]` when platform data exists, otherwise keep `[orbit_relative]`.

## Validation
- `python -m compileall -q utils next_pass.py`

## Impact
Sentinel-1 output now preserves platform-specific overpass rows and avoids cross-platform data mixing in cloudiness results.