### PR TITLE
Add `products` and `satellites` parameters to programmatic `run_next_pass` entry point

### DIFF
--- a/next_pass.py
+++ b/next_pass.py
@@ -244,6 +244,8 @@ def run_next_pass(
     date: str | None = None,
     functionality: str = "both",
     compute_cloudiness: bool = False,
+    products: List[str] | None = None,
+    satellites: List[str] | None = None
 ):
     """
     Programmatic entry point for next_pass.
@@ -268,12 +270,19 @@ def run_next_pass(
         functionality,
     ]
 
-    # Only append the -c flag if compute_cloudiness is True
     if compute_cloudiness:
         cli_args.append("-c")
 
     if date:
         cli_args += ["-d", date]
+    
+    if products:
+        cli_args.append("-p")
+        cli_args.extend(products)
+
+    if satellites:
+        cli_args.append("-s")
+        cli_args.extend(satellites)
 
     return main(cli_args)
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -244,8 +244,8 @@ def run_next_pass(
     date: str | None = None,
     functionality: str = "both",
     compute_cloudiness: bool = False,
-    products: List[str] | None = None,
-    satellites: List[str] | None = None
+    products: List[str] | str | None = None,
+    satellites: List[str] | str | None = None
 ):
     """
     Programmatic entry point for next_pass.
@@ -278,11 +278,17 @@ def run_next_pass(
     
     if products:
         cli_args.append("-p")
-        cli_args.extend(products)
+        if isinstance(products, str):
+            cli_args.extend([products])
+        else:
+            cli_args.extend(products)
 
     if satellites:
         cli_args.append("-s")
-        cli_args.extend(satellites)
+        if isinstance(satellites, str):
+            cli_args.extend([satellites])
+        else:
+            cli_args.extend(satellites)
 
     return main(cli_args)
 


### PR DESCRIPTION
This PR exposes the `-p/--products` and `-s/--satellites` CLI arguments to the programmatic `run_next_pass` python wrapper.

The `disasters` pipeline relies on `run_next_pass` to query Earthdata and discover available granules. Exposing these parameters programmatically allows the `disasters` module to pass arrays of specific products and satellite constellations directly into the `next_pass` search engine, enabling multi-product searches without relying on CLI calls.

### Updates

- Added `products: List[str] | None` and `satellites: List[str] | None` to the `run_next_pass` function signature.
- Updated the internal cli_args builder logic to safely map and append these lists before triggering `main()`.