### PR TITLE
Enhancing Tide Station Selection and Display 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Claude documentation
+claude_md/

--- a/tests/test_sentinel_pass.py
+++ b/tests/test_sentinel_pass.py
@@ -171,7 +171,7 @@ def test_next_sentinel_pass_returns_tide_for_point_aoi(monkeypatch):
     monkeypatch.setattr(
         sentinel_pass,
         "make_get_tide_for_row",
-        lambda aoi_geometry: (lambda row: [{"nearest": "1.23(H-rising)", "per_station": {"9432780": "1.23(H-rising)"}}]),
+        lambda aoi_geometry, station_dicts: (lambda row: [{"nearest": "1.23(H-rising)", "per_station": {"9432780": "1.23(H-rising)"}}]),
     )
     monkeypatch.setattr(sentinel_pass, "format_collects", lambda grouped: "tide-table")
     monkeypatch.setattr(sentinel_pass, "build_collect_summaries", lambda grouped: ["tide-summary"])

--- a/utils/sentinel_pass.py
+++ b/utils/sentinel_pass.py
@@ -336,20 +336,26 @@ def next_sentinel_pass(
         noaa_stations = None
         if arg_tide:
             collects_grouped["tide"] = None
-            LOGGER.info(
-                "Calculating tides for %d overpasses ...",
-                num_rows,
-            )
-            get_tide_for_row = make_get_tide_for_row(geometry)
-            collects_grouped["tide"] = collects_grouped.apply(
-                get_tide_for_row,
-                axis=1,
-            )
+            # Get stations once for the full AOI (used for all overpasses and map display)
             try:
                 noaa_stations = get_stations_in_aoi(geometry)
+                if not noaa_stations:
+                    LOGGER.warning("No NOAA stations found in AOI - tide predictions will be empty")
             except Exception as e:
-                LOGGER.warning("Could not retrieve NOAA station locations for map: %s", e)
+                LOGGER.warning("Could not retrieve NOAA stations for AOI: %s", e)
                 noaa_stations = None
+
+            if noaa_stations:
+                LOGGER.info(
+                    "Calculating tides for %d overpasses using %d stations ...",
+                    num_rows,
+                    len(noaa_stations),
+                )
+                get_tide_for_row = make_get_tide_for_row(geometry, noaa_stations)
+                collects_grouped["tide"] = collects_grouped.apply(
+                    get_tide_for_row,
+                    axis=1,
+                )
         return {
             "next_collect_info": format_collects(collects_grouped),
             "next_collect_geometry": collects_grouped["geometry"].tolist(),

--- a/utils/tide_prediction.py
+++ b/utils/tide_prediction.py
@@ -152,7 +152,6 @@ def get_stations_in_aoi(
     return [station for _, station in nearby[:max_stations]]
 
 
-
 def interpolate_tide(times, values, target_dt):
     for i in range(len(times) - 1):
         t1 = parse_datetime(times[i])
@@ -213,19 +212,29 @@ def _find_nearest_hilo_label(hilo_predictions: list, target_dt: datetime) -> str
 def get_tide_info_batch(
     polygon: BaseGeometry,
     target_isos: list,
+    station_dicts: list,
     allow_interpolation: bool = True,
     session: Optional[requests.Session] = None,
 ) -> list:
-    """Return a dict per target time with 'nearest' (table) and 'per_station' (map) values."""
+    """Return a dict per target time with 'nearest' (table) and 'per_station' (map) values.
+
+    Args:
+        polygon: AOI geometry (used only for finding centroid to determine "nearest" station)
+        target_isos: List of ISO datetime strings for tide predictions
+        station_dicts: List of station dicts from get_stations_in_aoi()
+        allow_interpolation: Whether to interpolate tide values between hourly predictions
+        session: Optional requests.Session for connection pooling
+
+    Returns:
+        List of dicts with 'nearest' and 'per_station' tide data, or None for missing data
+    """
 
     if session is None:
         session = requests.Session()
 
     try:
-        station_dicts = get_stations_in_aoi(polygon)
-
         if not station_dicts:
-            LOGGER.warning("No stations in polygon")
+            LOGGER.warning("No stations provided")
             return [None] * len(target_isos)
 
         # Find nearest station to polygon centroid
@@ -318,7 +327,16 @@ def get_tide_info_batch(
         return [None] * len(target_isos)
 
 
-def make_get_tide_for_row(aoi_geometry):
+def make_get_tide_for_row(aoi_geometry, station_dicts):
+    """Create a function to get tide info for each overpass row.
+
+    Args:
+        aoi_geometry: Full AOI geometry (used for finding centroid)
+        station_dicts: List of station dicts from get_stations_in_aoi() - reused for all overpasses
+
+    Returns:
+        Function that takes a dataframe row and returns tide info
+    """
     def get_tide_for_row(row):
         times = row["begin_date"]
 
@@ -331,15 +349,10 @@ def make_get_tide_for_row(aoi_geometry):
                 t = t.strftime("%Y-%m-%dT%H:%M:%S")
             target_isos.append(t)
 
-        if row.geometry is not None:
-            intersection = row.geometry.intersection(aoi_geometry)
-            polygon = aoi_geometry if intersection.is_empty else intersection
-        else:
-            polygon = aoi_geometry
-
         return get_tide_info_batch(
-            polygon=polygon,
+            polygon=aoi_geometry,
             target_isos=target_isos,
+            station_dicts=station_dicts,
             allow_interpolation=True,
         )
 


### PR DESCRIPTION
This PR replace the definition of the tide station inside the intersection between the AOI and overpass by simply recovering all stations inside the AOI and getting their measurement for each overpass at the relevant date/time. Below is a complete summary of the tide station selection logic as implemented now: 
+ For Point AOIs:
- System finds up to 3 nearest NOAA tide stations within 50km
- Those stations are used for ALL overpass times
- Map displays those exact stations

+ For Polygon AOIs:
- If stations exist inside the polygon : uses ALL stations inside (no limit)
- If no stations inside : uses up to 3 nearest stations within 50km
- Those stations are used for ALL overpass times  
- Map displays those exact stations

-> Result: consistency since the map shows exactly the stations used for calculations.

-- Key improvement from the fix implemented in this PR
++ Before:
- Each overpass selected stations based on its intersection with the AOI
- Overpass 1 might use stations A, B, C
- Overpass 2 might use stations A, D
- Map showed stations from the full AOI
- Result: Mismatched stations. Some used in calculations but not shown on map

++ After:
- All overpasses use the same AOI-based stations
- Stations selected ONCE at the start
- All overpasses use stations A, B, C
- Map shows stations A, B, C
- Result: Perfect match. map shows exactly what was used

The fix ensures: What you see on the map is exactly what's being used in the calculations - no more missing station markers.

The fix was tested for the below three locations/regions. Please re-run these if you would like to check the consistency of the tide station selection:
- Portland area: next-pass -b 43.22 45.15 -124.398 -122.2 -t
- LA area : next-pass -b 33.20 34.37 -118.97 -116.64 -t
- Florida: next-pass -b 24.29 26.27 -82.33 -79.59 -t

