### PR TITLE
Add support for fetching source HLS scenes to OPERA metadata export

### DIFF
--- a/next_pass.py
+++ b/next_pass.py
@@ -398,10 +398,9 @@ def main(cli_args: Any = None):
         )
         export_opera_products(
             results_opera,
-            results_opera,
             timestamp_dir,
             compute_cloudiness=args.cloudiness,
-            include_hls=getattr(args, 'include_hls', False)
+            include_hls=getattr(args, "include_hls", False),
         )
         make_opera_granule_map(results_opera, args.bbox, timestamp_dir)
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -134,6 +134,11 @@ def create_parser() -> argparse.ArgumentParser:
             "in format YYYY-MM-DDTHH:MM"
         ),
     )
+    parser.add_argument(
+        "--include-hls",
+        action="store_true",
+        help="Fetch and append corresponding source HLS scenes for OPERA HLS products.",
+    )
     return parser
 
 
@@ -254,6 +259,7 @@ def run_next_pass(
     functionality: str = "both",
     compute_cloudiness: bool = False,
     compute_tide: bool = False,
+    include_hls: bool = False,
     products: List[str] | str | None = None,
     satellites: List[str] | str | None = None,
 ):
@@ -286,6 +292,8 @@ def run_next_pass(
         cli_args.append("-c")
     if compute_tide:
         cli_args.append("-t")
+    if include_hls:
+        cli_args.append("--include-hls")
 
     if date:
         cli_args += ["-d", date]
@@ -389,7 +397,11 @@ def main(cli_args: Any = None):
             timestamp_dir,
         )
         export_opera_products(
-            results_opera, timestamp_dir, compute_cloudiness=args.cloudiness
+            results_opera,
+            results_opera,
+            timestamp_dir,
+            compute_cloudiness=args.cloudiness,
+            include_hls=getattr(args, 'include_hls', False)
         )
         make_opera_granule_map(results_opera, args.bbox, timestamp_dir)
 

--- a/next_pass.py
+++ b/next_pass.py
@@ -259,9 +259,9 @@ def run_next_pass(
     functionality: str = "both",
     compute_cloudiness: bool = False,
     compute_tide: bool = False,
-    include_hls: bool = False,
     products: List[str] | str | None = None,
     satellites: List[str] | str | None = None,
+    include_hls: bool = False,
 ):
     """
     Programmatic entry point for next_pass.

--- a/tests/test_hls.py
+++ b/tests/test_hls.py
@@ -1,0 +1,36 @@
+import earthaccess
+import pytest
+
+from utils.opera_products import fetch_hls_granule_links
+
+
+@pytest.mark.integration
+def test_live_cmr_fallback_search():
+    """
+    Hit the live CMR API to ensure earthaccess.search_data still accepts
+    our specific combination of arguments without throwing an error.
+    """
+    try:
+        results = earthaccess.search_data(
+            short_name=["HLSS30", "HLSL30"],
+            temporal=("2023-01-01T00:00:00", "2023-01-01T23:59:59"),
+            bounding_box=(-120.0, 30.0, -119.0, 31.0),
+        )
+        assert isinstance(results, list)
+    except Exception as e:
+        pytest.fail(f"Live CMR search failed! The API contract may have changed: {e}")
+
+
+@pytest.mark.integration
+def test_live_hls_granule_fetch():
+    """
+    Hit the live CMR API to ensure our fetch_hls_granule_links function
+    successfully queries and extracts data links for a known collection.
+    """
+    known_granule_prefix = "HLS.S30.T11SLT.2023001"
+
+    try:
+        links = fetch_hls_granule_links(known_granule_prefix)
+        assert isinstance(links, list)
+    except Exception as e:
+        pytest.fail(f"Live CMR granule fetch failed: {e}")

--- a/tests/test_opera_products.py
+++ b/tests/test_opera_products.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import zipfile
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -121,3 +122,135 @@ def test_export_opera_products_writes_workbook_and_skips_cloudiness_when_disable
         assert payload[0][0] == "Dataset"
         assert payload[1][1] == "granule-1"
         assert payload[1][5] == "https://example.com/file_B01_WTR.tif"
+
+
+@patch("utils.opera_products.earthaccess.search_data")
+def test_fetch_hls_granule_links(mock_search):
+    # Setup mock successful response
+    mock_result = MagicMock()
+    mock_result.data_links.return_value = ["https://example.com/B04.tif"]
+    mock_search.return_value = [mock_result]
+
+    # Test 1: Successful fetch
+    links = opera_products.fetch_hls_granule_links("HLS.S30.T11SLT.20230101.v2.0")
+    assert links == ["https://example.com/B04.tif"]
+    mock_search.assert_called_with(
+        short_name="HLSS30", granule_name="HLS.S30.T11SLT.20230101.v2.0"
+    )
+
+    # Test 2: Error case (API failure)
+    mock_search.side_effect = Exception("API Timeout")
+    error_links = opera_products.fetch_hls_granule_links("HLS.S30.T11SLT.20230101.v2.0")
+    assert error_links is None
+
+
+@patch("utils.opera_products.fetch_hls_granule_links")
+def test_export_hls_band_mapping_and_input_granules(mock_fetch_links, tmp_path):
+    # Simulate an S30 and L30 response with their specific band names
+    mock_fetch_links.side_effect = [
+        [
+            "https://fake/B02.tif",
+            "https://fake/B03.tif",
+            "https://fake/B04.tif",
+            "https://fake/B8A.tif",
+            "https://fake/Fmask.tif",
+        ],  # S30 response
+        [
+            "https://fake/B02.tif",
+            "https://fake/B03.tif",
+            "https://fake/B04.tif",
+            "https://fake/B05.tif",
+            "https://fake/Fmask.tif",
+        ],  # L30 response
+    ]
+
+    mock_results = {
+        "OPERA_L3_DSWX-HLS_V1": {
+            "results": [
+                {
+                    "umm": {
+                        "GranuleUR": "OPERA_S30",
+                        "InputGranules": ["HLS.S30.T11SLT"],
+                    }
+                },
+                {
+                    "umm": {
+                        "GranuleUR": "OPERA_L30",
+                        "InputGranules": ["HLS.L30.T11SLT"],
+                    }
+                },
+            ],
+            "gdf": None,  # Skipping geometry for simplicity
+        }
+    }
+
+    # Run the export function
+    opera_products.export_opera_products(
+        mock_results, tmp_path, compute_cloudiness=False, include_hls=True
+    )
+
+    # Read the generated Excel file to verify mappings
+    from openpyxl import load_workbook
+
+    wb = load_workbook(tmp_path / "opera_products_metadata.xlsx")
+    ws = wb.active
+
+    # Row 2 is S30 (B8A for NIR)
+    assert ws.cell(row=2, column=18).value == "https://fake/B04.tif"  # Red
+    assert ws.cell(row=2, column=21).value == "https://fake/B8A.tif"  # NIR
+    assert ws.cell(row=2, column=22).value == "https://fake/Fmask.tif"
+
+    # Row 3 is L30 (B05 for NIR)
+    assert ws.cell(row=3, column=21).value == "https://fake/B05.tif"  # NIR for Landsat
+
+
+@patch("utils.opera_products.earthaccess.search_data")
+def test_export_hls_fallback_cmr_search(mock_cmr_search, tmp_path):
+    # Setup mock geometry and mock CMR response
+    mock_geom = MagicMock()
+    mock_geom.bounds = (-120, 30, -119, 31)
+    mock_geom.wkt = "POLYGON((-120 30, -119 30, -119 31, -120 31, -120 30))"
+
+    mock_hls_result = MagicMock()
+    mock_hls_result.get.return_value = {"GranuleUR": "HLS.S30.T11SLT.123"}
+    mock_hls_result.data_links.return_value = ["https://fallback/B04.tif"]
+    mock_cmr_search.return_value = [mock_hls_result]
+
+    # Provide results missing "InputGranules", forcing the fallback logic
+    mock_results = {
+        "OPERA_L3_DIST-ALERT-HLS_V1": {
+            "results": [
+                {
+                    "umm": {
+                        "GranuleUR": "OPERA_L3_DIST-ALERT-HLS_T11SLT_20230101",
+                        "TemporalExtent": {
+                            "RangeDateTime": {
+                                "BeginningDateTime": "2023-01-01T00:00:00Z"
+                            }
+                        },
+                    }
+                }
+            ],
+            "gdf": FakeFrame([{"geometry": mock_geom}]),
+        }
+    }
+
+    opera_products.export_opera_products(
+        mock_results, tmp_path, compute_cloudiness=False, include_hls=True
+    )
+
+    # Verify fallback search triggered with bounds and date
+    mock_cmr_search.assert_called_once()
+    kwargs = mock_cmr_search.call_args.kwargs
+    assert kwargs["bounding_box"] == (-120, 30, -119, 31)
+    assert kwargs["temporal"] == ("2023-01-01T00:00:00", "2023-01-01T23:59:59")
+
+    # Verify the fallback successfully mapped the data
+    from openpyxl import load_workbook
+
+    wb = load_workbook(tmp_path / "opera_products_metadata.xlsx")
+    ws = wb.active
+    assert (
+        ws.cell(row=2, column=17).value == "HLS.S30.T11SLT.123"
+    )  # Extracted Fallback ID
+    assert ws.cell(row=2, column=18).value == "https://fallback/B04.tif"

--- a/utils/opera_products.py
+++ b/utils/opera_products.py
@@ -259,7 +259,8 @@ def export_opera_products(
             "HLS Download URL (B04/Red)", 
             "HLS Download URL (B03/Green)", 
             "HLS Download URL (B02/Blue)",
-            "HLS Download URL (B8A/B05/NIR)"
+            "HLS Download URL (B8A/B05/NIR)",
+            "HLS Download URL (Fmask)"
         ])
     ws.append(headers)
 
@@ -383,6 +384,7 @@ def export_opera_products(
                 hls_green = "N/A"
                 hls_blue = "N/A"
                 hls_nir = "N/A"
+                hls_fmask = "N/A"
                 
                 if "HLS" in dataset:
                     hls_links = []
@@ -437,9 +439,11 @@ def export_opera_products(
                                 hls_nir = href
                             elif "L30" in hls_granule_id and ("B05" in href or "band05" in href.lower()):
                                 hls_nir = href
+                            elif "Fmask" in href or "fmask" in href.lower():
+                                hls_fmask = href
 
-                # Appends all 5 elements to keep data rows and headers perfectly 1-to-1
-                row_data.extend([hls_granule_id, hls_red, hls_green, hls_blue, hls_nir])
+                # Appends all 6 elements to keep data rows and headers perfectly 1-to-1
+                row_data.extend([hls_granule_id, hls_red, hls_green, hls_blue, hls_nir, hls_fmask])
 
             ws.append(row_data)
             

--- a/utils/opera_products.py
+++ b/utils/opera_products.py
@@ -173,17 +173,19 @@ def find_print_available_opera_products(
     return results_dict
 
 
-def fetch_hls_granule_links(granule_id: str) -> list:
+def fetch_hls_granule_links(granule_id: str) -> list | None:
     """Fetch the CMR metadata for a specific HLS granule ID to get download links."""
     collection = "HLSS30" if "S30" in granule_id else "HLSL30"
     try:
-        results = earthaccess.search_data(short_name=collection, granule_ur=granule_id)
+        results = earthaccess.search_data(
+            short_name=collection, granule_name=granule_id
+        )
         if results:
             return results[0].data_links()
+        return []
     except Exception as e:
         LOGGER.error("Failed to fetch HLS granule %s: %s", granule_id, e)
-
-    return []
+        return None
 
 
 def describe_cloud_cover(cover_percent: float) -> str:
@@ -390,6 +392,9 @@ def export_opera_products(
 
                     # Try to extract directly from InputGranules (Standard for DSWx)
                     input_granules = umm.get("InputGranules", [])
+
+                    # OPERA HLS products (DSWx/DIST) are mapped 1:1 with source HLS MGRS tiles.
+                    # Because there is only one source scene per product, retrieving the first match is expected.
                     raw_hls = next(
                         (g for g in input_granules if g.startswith("HLS.")), "N/A"
                     )
@@ -401,6 +406,15 @@ def export_opera_products(
                         )
                         hls_links = fetch_hls_granule_links(hls_granule_id)
 
+                        if hls_links is None:
+                            hls_red = hls_green = hls_blue = hls_nir = hls_fmask = (
+                                "API_ERROR"
+                            )
+                        elif not hls_links:
+                            hls_red = hls_green = hls_blue = hls_nir = hls_fmask = (
+                                "NOT_FOUND"
+                            )
+
                     # Fallback: Search CMR dynamically via Tile ID and Date (Required for DIST)
                     else:
                         try:
@@ -411,9 +425,9 @@ def export_opera_products(
                                 None,
                             )
 
-                            if tile_id and start_time != "N/A":
+                            if tile_id and start_time != "N/A" and geom:
                                 date_only = start_time.split("T")[0]
-                                search_bounds = geom.bounds if geom else None
+                                search_bounds = geom.bounds
 
                                 # Query CMR for all HLS granules on that day over the bounding box
                                 hls_results = earthaccess.search_data(
@@ -425,37 +439,48 @@ def export_opera_products(
                                     bounding_box=search_bounds,
                                 )
 
-                                # Filter the results to find the one matching the exact Tile ID
-                                for r in hls_results:
-                                    g_name = r.get("umm", {}).get("GranuleUR", "")
-                                    if f".{tile_id}." in g_name:
-                                        hls_links = r.data_links()
-                                        hls_granule_id = ".".join(g_name.split(".")[:6])
-                                        break
+                                if not hls_results:
+                                    hls_red = hls_green = hls_blue = hls_nir = (
+                                        hls_fmask
+                                    ) = "NOT_FOUND"
+                                else:
+                                    # Filter the results to find the one matching the exact Tile ID
+                                    for r in hls_results:
+                                        g_name = r.get("umm", {}).get("GranuleUR", "")
+                                        if f".{tile_id}." in g_name:
+                                            hls_links = r.data_links()
+                                            hls_granule_id = ".".join(
+                                                g_name.split(".")[:6]
+                                            )
+                                            break
                         except Exception as e:
                             LOGGER.warning(
                                 f"Failed to dynamically locate HLS granule for {granule_id}: {e}"
                             )
+                            hls_red = hls_green = hls_blue = hls_nir = hls_fmask = (
+                                "API_ERROR"
+                            )
 
                     # Map bands based on HLSS30 or HLSL30 naming conventions
-                    for href in hls_links:
-                        if href.endswith(".tif"):
-                            if "B04" in href or "band04" in href.lower():
-                                hls_red = href
-                            elif "B03" in href or "band03" in href.lower():
-                                hls_green = href
-                            elif "B02" in href or "band02" in href.lower():
-                                hls_blue = href
-                            elif "S30" in hls_granule_id and (
-                                "B8A" in href or "band8a" in href.lower()
-                            ):
-                                hls_nir = href
-                            elif "L30" in hls_granule_id and (
-                                "B05" in href or "band05" in href.lower()
-                            ):
-                                hls_nir = href
-                            elif "Fmask" in href or "fmask" in href.lower():
-                                hls_fmask = href
+                    if hls_links:
+                        for href in hls_links:
+                            if href.endswith(".tif"):
+                                if "B04" in href or "band04" in href.lower():
+                                    hls_red = href
+                                elif "B03" in href or "band03" in href.lower():
+                                    hls_green = href
+                                elif "B02" in href or "band02" in href.lower():
+                                    hls_blue = href
+                                elif "S30" in hls_granule_id and (
+                                    "B8A" in href or "band8a" in href.lower()
+                                ):
+                                    hls_nir = href
+                                elif "L30" in hls_granule_id and (
+                                    "B05" in href or "band05" in href.lower()
+                                ):
+                                    hls_nir = href
+                                elif "Fmask" in href or "fmask" in href.lower():
+                                    hls_fmask = href
 
                 # Appends all 6 elements to keep data rows and headers perfectly 1-to-1
                 row_data.extend(

--- a/utils/opera_products.py
+++ b/utils/opera_products.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import earthaccess
 import leafmap
 import pandas as pd
 from dateutil.relativedelta import relativedelta
@@ -172,6 +173,22 @@ def find_print_available_opera_products(
     return results_dict
 
 
+def fetch_hls_granule_links(granule_id: str) -> list:
+    """Fetch the CMR metadata for a specific HLS granule ID to get download links."""
+    collection = "HLSS30" if "S30" in granule_id else "HLSL30"
+    try:
+        results = earthaccess.search_data(
+            short_name=collection,
+            granule_ur=granule_id
+        )
+        if results:
+            return results[0].data_links()
+    except Exception as e:
+        LOGGER.error("Failed to fetch HLS granule %s: %s", granule_id, e)
+    
+    return []
+
+
 def describe_cloud_cover(cover_percent: float) -> str:
     """Return a short description string for a given cloud cover %."""
     if cover_percent > 75:
@@ -188,7 +205,11 @@ def describe_cloud_cover(cover_percent: float) -> str:
 
 
 def export_opera_products(
-    results_dict: dict, timestamp_dir, result_s1=None, compute_cloudiness: bool = True
+        results_dict: dict,
+        timestamp_dir,
+        result_s1=None,
+        compute_cloudiness: bool = True,
+        include_hls: bool = False
 ) -> None:
     """
     Export OPERA products to an Excel file and log cloudiness summary.
@@ -203,6 +224,8 @@ def export_opera_products(
         Currently unused, kept for API compatibility.
     compute_cloudiness : bool
         Whether to compute cloudiness from CLOUD layers. Set to False to skip and save time.
+    include_hls : bool
+        Whether to include HLS products in the export. Set to False to skip HLS products in xls output.
     """
     output_file = timestamp_dir / "opera_products_metadata.xlsx"
     wb = Workbook()
@@ -229,6 +252,15 @@ def export_opera_products(
         "Download URL CSLC-VV",
         "Geometry (WKT)",
     ]
+
+    if include_hls:
+        headers.extend([
+            "Source HLS Granule ID", 
+            "HLS Download URL (B04/Red)", 
+            "HLS Download URL (B03/Green)", 
+            "HLS Download URL (B02/Blue)",
+            "HLS Download URL (B8A/B05/NIR)"
+        ])
     ws.append(headers)
 
     # Apply bold to header cells
@@ -323,28 +355,94 @@ def export_opera_products(
                     overall_cloudy_area += area * cloud_cover_percent / 100.0
                     overall_area += area
 
-            # Write data row
-            ws.append(
-                [
-                    dataset,
-                    granule_id,
-                    start_time,
-                    end_time,
-                    cloud_cover_percent,
-                    urls["water"],
-                    urls["bwater"],
-                    urls["water_conf"],
-                    urls["veg_anom_max"],
-                    urls["veg_dist_status"],
-                    urls["veg_dist_date"],
-                    urls["veg_dist_conf"],
-                    urls["rtc-vv"],
-                    urls["rtc-vh"],
-                    urls["cslc-vv"],
-                    geom_wkt,
-                ]
-            )
+            # Write base data row
+            row_data = [
+                dataset,
+                granule_id,
+                start_time,
+                end_time,
+                cloud_cover_percent,
+                urls["water"],
+                urls["bwater"],
+                urls["water_conf"],
+                urls["veg_anom_max"],
+                urls["veg_dist_status"],
+                urls["veg_dist_date"],
+                urls["veg_dist_conf"],
+                urls["rtc-vv"],
+                urls["rtc-vh"],
+                urls["cslc-vv"],
+                geom_wkt,
+            ]
 
+            # Only check for HLS granules if it is an HLS-derived OPERA product
+            if include_hls:
+                # Initialize variables here to guarantee they exist
+                hls_granule_id = "N/A"
+                hls_red = "N/A"
+                hls_green = "N/A"
+                hls_blue = "N/A"
+                hls_nir = "N/A"
+                
+                if "HLS" in dataset:
+                    hls_links = []
+                    
+                    # Try to extract directly from InputGranules (Standard for DSWx)
+                    input_granules = umm.get("InputGranules", [])
+                    raw_hls = next((g for g in input_granules if g.startswith("HLS.")), "N/A")
+                    
+                    if raw_hls != "N/A":
+                        parts = raw_hls.split(".")
+                        hls_granule_id = ".".join(parts[:6]) if len(parts) >= 6 else raw_hls
+                        hls_links = fetch_hls_granule_links(hls_granule_id)
+                        
+                    # Fallback: Search CMR dynamically via Tile ID and Date (Required for DIST)
+                    else:
+                        try:
+                            # Extract Tile ID (e.g., T11SLT) from the OPERA GranuleUR
+                            parts = granule_id.split('_')
+                            tile_id = next((p for p in parts if p.startswith('T') and len(p) == 6), None)
+                            
+                            if tile_id and start_time != "N/A":
+                                date_only = start_time.split("T")[0]
+                                search_bounds = geom.bounds if geom else None
+                                
+                                # Query CMR for all HLS granules on that day over the bounding box
+                                hls_results = earthaccess.search_data(
+                                    short_name=["HLSS30", "HLSL30"],
+                                    temporal=(f"{date_only}T00:00:00", f"{date_only}T23:59:59"),
+                                    bounding_box=search_bounds
+                                )
+                                
+                                # Filter the results to find the one matching the exact Tile ID
+                                for r in hls_results:
+                                    g_name = r.get("umm", {}).get("GranuleUR", "")
+                                    if f".{tile_id}." in g_name:
+                                        hls_links = r.data_links()
+                                        hls_granule_id = ".".join(g_name.split(".")[:6])
+                                        break
+                        except Exception as e:
+                            LOGGER.warning(f"Failed to dynamically locate HLS granule for {granule_id}: {e}")
+                            
+                    # Map bands based on HLSS30 or HLSL30 naming conventions
+                    for href in hls_links:
+                        if href.endswith(".tif"):
+                            if "B04" in href or "band04" in href.lower():
+                                hls_red = href
+                            elif "B03" in href or "band03" in href.lower():
+                                hls_green = href
+                            elif "B02" in href or "band02" in href.lower():
+                                hls_blue = href
+                            elif "S30" in hls_granule_id and ("B8A" in href or "band8a" in href.lower()):
+                                hls_nir = href
+                            elif "L30" in hls_granule_id and ("B05" in href or "band05" in href.lower()):
+                                hls_nir = href
+
+                # Appends all 5 elements to keep data rows and headers perfectly 1-to-1
+                row_data.extend([hls_granule_id, hls_red, hls_green, hls_blue, hls_nir])
+
+            ws.append(row_data)
+            
         if compute_cloudiness and overall_area > 0:
             overall_cloud_cover_percent = 100.0 * (overall_cloudy_area / overall_area)
             cover_description = describe_cloud_cover(overall_cloud_cover_percent)

--- a/utils/opera_products.py
+++ b/utils/opera_products.py
@@ -177,15 +177,12 @@ def fetch_hls_granule_links(granule_id: str) -> list:
     """Fetch the CMR metadata for a specific HLS granule ID to get download links."""
     collection = "HLSS30" if "S30" in granule_id else "HLSL30"
     try:
-        results = earthaccess.search_data(
-            short_name=collection,
-            granule_ur=granule_id
-        )
+        results = earthaccess.search_data(short_name=collection, granule_ur=granule_id)
         if results:
             return results[0].data_links()
     except Exception as e:
         LOGGER.error("Failed to fetch HLS granule %s: %s", granule_id, e)
-    
+
     return []
 
 
@@ -205,11 +202,11 @@ def describe_cloud_cover(cover_percent: float) -> str:
 
 
 def export_opera_products(
-        results_dict: dict,
-        timestamp_dir,
-        result_s1=None,
-        compute_cloudiness: bool = True,
-        include_hls: bool = False
+    results_dict: dict,
+    timestamp_dir,
+    result_s1=None,
+    compute_cloudiness: bool = True,
+    include_hls: bool = False,
 ) -> None:
     """
     Export OPERA products to an Excel file and log cloudiness summary.
@@ -254,14 +251,16 @@ def export_opera_products(
     ]
 
     if include_hls:
-        headers.extend([
-            "Source HLS Granule ID", 
-            "HLS Download URL (B04/Red)", 
-            "HLS Download URL (B03/Green)", 
-            "HLS Download URL (B02/Blue)",
-            "HLS Download URL (B8A/B05/NIR)",
-            "HLS Download URL (Fmask)"
-        ])
+        headers.extend(
+            [
+                "Source HLS Granule ID",
+                "HLS Download URL (B04/Red)",
+                "HLS Download URL (B03/Green)",
+                "HLS Download URL (B02/Blue)",
+                "HLS Download URL (B8A/B05/NIR)",
+                "HLS Download URL (Fmask)",
+            ]
+        )
     ws.append(headers)
 
     # Apply bold to header cells
@@ -385,37 +384,47 @@ def export_opera_products(
                 hls_blue = "N/A"
                 hls_nir = "N/A"
                 hls_fmask = "N/A"
-                
+
                 if "HLS" in dataset:
                     hls_links = []
-                    
+
                     # Try to extract directly from InputGranules (Standard for DSWx)
                     input_granules = umm.get("InputGranules", [])
-                    raw_hls = next((g for g in input_granules if g.startswith("HLS.")), "N/A")
-                    
+                    raw_hls = next(
+                        (g for g in input_granules if g.startswith("HLS.")), "N/A"
+                    )
+
                     if raw_hls != "N/A":
                         parts = raw_hls.split(".")
-                        hls_granule_id = ".".join(parts[:6]) if len(parts) >= 6 else raw_hls
+                        hls_granule_id = (
+                            ".".join(parts[:6]) if len(parts) >= 6 else raw_hls
+                        )
                         hls_links = fetch_hls_granule_links(hls_granule_id)
-                        
+
                     # Fallback: Search CMR dynamically via Tile ID and Date (Required for DIST)
                     else:
                         try:
                             # Extract Tile ID (e.g., T11SLT) from the OPERA GranuleUR
-                            parts = granule_id.split('_')
-                            tile_id = next((p for p in parts if p.startswith('T') and len(p) == 6), None)
-                            
+                            parts = granule_id.split("_")
+                            tile_id = next(
+                                (p for p in parts if p.startswith("T") and len(p) == 6),
+                                None,
+                            )
+
                             if tile_id and start_time != "N/A":
                                 date_only = start_time.split("T")[0]
                                 search_bounds = geom.bounds if geom else None
-                                
+
                                 # Query CMR for all HLS granules on that day over the bounding box
                                 hls_results = earthaccess.search_data(
                                     short_name=["HLSS30", "HLSL30"],
-                                    temporal=(f"{date_only}T00:00:00", f"{date_only}T23:59:59"),
-                                    bounding_box=search_bounds
+                                    temporal=(
+                                        f"{date_only}T00:00:00",
+                                        f"{date_only}T23:59:59",
+                                    ),
+                                    bounding_box=search_bounds,
                                 )
-                                
+
                                 # Filter the results to find the one matching the exact Tile ID
                                 for r in hls_results:
                                     g_name = r.get("umm", {}).get("GranuleUR", "")
@@ -424,8 +433,10 @@ def export_opera_products(
                                         hls_granule_id = ".".join(g_name.split(".")[:6])
                                         break
                         except Exception as e:
-                            LOGGER.warning(f"Failed to dynamically locate HLS granule for {granule_id}: {e}")
-                            
+                            LOGGER.warning(
+                                f"Failed to dynamically locate HLS granule for {granule_id}: {e}"
+                            )
+
                     # Map bands based on HLSS30 or HLSL30 naming conventions
                     for href in hls_links:
                         if href.endswith(".tif"):
@@ -435,18 +446,24 @@ def export_opera_products(
                                 hls_green = href
                             elif "B02" in href or "band02" in href.lower():
                                 hls_blue = href
-                            elif "S30" in hls_granule_id and ("B8A" in href or "band8a" in href.lower()):
+                            elif "S30" in hls_granule_id and (
+                                "B8A" in href or "band8a" in href.lower()
+                            ):
                                 hls_nir = href
-                            elif "L30" in hls_granule_id and ("B05" in href or "band05" in href.lower()):
+                            elif "L30" in hls_granule_id and (
+                                "B05" in href or "band05" in href.lower()
+                            ):
                                 hls_nir = href
                             elif "Fmask" in href or "fmask" in href.lower():
                                 hls_fmask = href
 
                 # Appends all 6 elements to keep data rows and headers perfectly 1-to-1
-                row_data.extend([hls_granule_id, hls_red, hls_green, hls_blue, hls_nir, hls_fmask])
+                row_data.extend(
+                    [hls_granule_id, hls_red, hls_green, hls_blue, hls_nir, hls_fmask]
+                )
 
             ws.append(row_data)
-            
+
         if compute_cloudiness and overall_area > 0:
             overall_cloud_cover_percent = 100.0 * (overall_cloudy_area / overall_area)
             cover_description = describe_cloud_cover(overall_cloud_cover_percent)


### PR DESCRIPTION
This PR introduces the ability to fetch and append corresponding source HLS (Harmonized Landsat and Sentinel-2) scenes for OPERA products directly into the output `opera_products_metadata.xlsx`. By passing a new CLI flag, users can now automatically retrieve the download links for R/G/B/NIR, and Fmask bands associated with the corresponding OPERA granules.

### Key Changes
- Added `--include-hls` flag to `next_pass.py` to optionally trigger the fetching of source HLS scenes.  
- When `--include-hls` is active, the opera_products_metadata.xlsx file will include six new columns:
     - Source HLS Granule ID  
     - HLS Download URL (B04/Red)  
     - HLS Download URL (B03/Green)  
     - HLS Download URL (B02/Blue)  
     - HLS Download URL (B8A/B05/NIR)  
     - HLS Download URL (Fmask)  
   
- Utilizes the `earthaccess` library to fetch HLS data links. Implements a two-tiered search strategy to find the corresponding source scenes:  

     - Primary: Extracts the HLS granule ID directly from the OPERA product's InputGranules metadata (Standard for DSWx).  
     - Fallback: Dynamically searches CMR using the Tile ID, date, and bounding box (Required for DIST products). 
- Maps the Near-Infrared (NIR) band based on the specific HLS collection, accounting for naming differences between Sentinel-2 (HLSS30 uses B8A) and Landsat (HLSL30 uses B05).

### Test functionality 
The following command will return and `opera_products_metadata.xlsx` containing the corresponding HLS scenes.

```bash
next-pass -b 35.5 36 -107 -106 --include-hls
```