### PR TITLE
Remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest tests/ --cov=utils --cov=. --cov-report=xml --cov-report=term-missing
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
-          fail_ci_if_error: false
+          pytest tests/ --cov=utils --cov=. --cov-report=term-missing
 
   lint:
     name: Code Quality

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # NEXT PASS
 
 [![CI](https://github.com/OPERA-Cal-Val/next_pass/actions/workflows/ci.yml/badge.svg)](https://github.com/OPERA-Cal-Val/next_pass/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/OPERA-Cal-Val/next_pass/branch/main/graph/badge.svg)](https://codecov.io/gh/OPERA-Cal-Val/next_pass)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
- Remove codecov upload from CI workflow
- Remove codecov badge from README
- Keep pytest-cov for local coverage reports