### PR TITLE
Parallelize collection building and add nested progress bars for overpass fetching

### DIFF
--- a/next_pass.py
+++ b/next_pass.py
@@ -148,6 +148,7 @@ def find_next_overpass(args: argparse.Namespace, timestamp_dir: Path) -> dict:
     from utils.cloudiness import api_limit_reached
     from utils.landsat_pass import next_landsat_pass
     from utils.nisar_pass import next_nisar_pass
+    from utils.progress import overpass_progress
     from utils.sentinel_pass import next_sentinel_pass
     from utils.utils import bbox_to_geometry, bbox_type
 
@@ -177,31 +178,54 @@ def find_next_overpass(args: argparse.Namespace, timestamp_dir: Path) -> dict:
         pred_cloudiness and "sentinel-1" in selected and "sentinel-2" in selected
     )
 
-    # Fetch conditionally
-    if "sentinel-1" in selected:
-        LOGGER.info("Fetching Sentinel-1 data...")
-        sentinel1 = next_sentinel_pass(
-            "sentinel1", geometry, n_day_past, pred_cloudiness, pred_tide
-        )
+    # Fetch conditionally, wrapped in a master progress bar (one sub bar per
+    # satellite). The bar is disabled on non-TTY runs; the LOGGER.info lines
+    # below remain the feedback path in that case.
+    with overpass_progress(len(selected)) as progress:
+        if "sentinel-1" in selected:
+            LOGGER.info("Fetching Sentinel-1 data...")
+            with progress.satellite("Sentinel-1") as step_cb:
+                sentinel1 = next_sentinel_pass(
+                    "sentinel1",
+                    geometry,
+                    n_day_past,
+                    pred_cloudiness,
+                    pred_tide,
+                    step_cb=step_cb,
+                )
 
-    if "sentinel-2" in selected:
-        LOGGER.info("Fetching Sentinel-2 data...")
+        if "sentinel-2" in selected:
+            LOGGER.info("Fetching Sentinel-2 data...")
+            with progress.satellite("Sentinel-2") as step_cb:
+                if needs_weather_backoff and not api_limit_reached():
+                    LOGGER.info(
+                        "Waiting 1 min to avoid hitting cumulative weather API quota."
+                    )
+                    step_cb("Waiting on weather API quota")
+                    time.sleep(60)
 
-        if needs_weather_backoff and not api_limit_reached():
-            LOGGER.info("Waiting 1 min to avoid hitting cumulative weather API quota.")
-            time.sleep(60)
+                sentinel2 = next_sentinel_pass(
+                    "sentinel2",
+                    geometry,
+                    n_day_past,
+                    pred_cloudiness,
+                    pred_tide,
+                    step_cb=step_cb,
+                )
 
-        sentinel2 = next_sentinel_pass(
-            "sentinel2", geometry, n_day_past, pred_cloudiness, pred_tide
-        )
+        if "nisar" in selected:
+            LOGGER.info("Fetching NISAR data...")
+            with progress.satellite("NISAR") as step_cb:
+                nisar = next_nisar_pass(
+                    geometry, n_day_past, arg_tide=pred_tide, step_cb=step_cb
+                )
 
-    if "nisar" in selected:
-        LOGGER.info("Fetching NISAR data...")
-        nisar = next_nisar_pass(geometry, n_day_past, arg_tide=pred_tide)
-
-    if "landsat" in selected:
-        LOGGER.info("Fetching Landsat data...")
-        landsat = next_landsat_pass(lat_min, lon_min, geometry, n_day_past, pred_tide)
+        if "landsat" in selected:
+            LOGGER.info("Fetching Landsat data...")
+            with progress.satellite("Landsat") as step_cb:
+                landsat = next_landsat_pass(
+                    lat_min, lon_min, geometry, n_day_past, pred_tide, step_cb=step_cb
+                )
 
     return {
         "sentinel-1": sentinel1,
@@ -328,6 +352,10 @@ def main(cli_args: Any = None):
         level=args.log_level.upper(),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+
+    # Silence noisy third-party INFO chatter (e.g. pyogrio "Created N records")
+    for noisy in ("pyogrio", "pyogrio._io", "fiona", "fiona._env"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
 
     from utils.opera_products import (
         export_opera_products,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ tabulate
 yagmail
 openpyxl>=3.1.5
 timezonefinder
+rich
 pre-commit>=4.6.1
 black>=26.5.1
 isort>=8.0.1

--- a/tests/test_collection_builder.py
+++ b/tests/test_collection_builder.py
@@ -53,6 +53,7 @@ def test_build_sentinel_collection_uses_cached_and_parsed_files(monkeypatch, tmp
         (),
         {
             "info": lambda *args, **kwargs: None,
+            "debug": lambda *args, **kwargs: None,
             "warning": lambda *args, **kwargs: None,
             "error": lambda *args, **kwargs: None,
         },
@@ -112,6 +113,7 @@ def test_build_sentinel_collection_returns_empty_path_when_no_frames(
         (),
         {
             "info": lambda *args, **kwargs: None,
+            "debug": lambda *args, **kwargs: None,
             "warning": lambda *args, **kwargs: None,
             "error": lambda *args, **kwargs: None,
         },

--- a/tests/test_next_pass_cli.py
+++ b/tests/test_next_pass_cli.py
@@ -85,17 +85,17 @@ next_pass.datetime = FakeDateTime
 cloudiness.api_limit_reached = lambda: True
 utils_mod.bbox_type = lambda bbox: bbox
 utils_mod.bbox_to_geometry = fake_bbox_to_geometry
-sentinel_pass.next_sentinel_pass = lambda sat, geometry, n_day_past, pred_cloudiness, pred_tide=False: {{
+sentinel_pass.next_sentinel_pass = lambda sat, geometry, n_day_past, pred_cloudiness, pred_tide=False, **kwargs: {{
     "next_collect_info": sat,
     "next_collect_geometry": [geometry],
     "next_collect_summary": [sat],
 }}
-nisar_pass.next_nisar_pass = lambda geometry, n_day_past, arg_tide=False: {{
+nisar_pass.next_nisar_pass = lambda geometry, n_day_past, arg_tide=False, **kwargs: {{
     "next_collect_info": "nisar",
     "next_collect_geometry": [geometry],
     "next_collect_summary": ["nisar"],
 }}
-landsat_pass.next_landsat_pass = lambda lat, lon, geometry, n_day_past, arg_tide=False: {{
+landsat_pass.next_landsat_pass = lambda lat, lon, geometry, n_day_past, arg_tide=False, **kwargs: {{
     "next_collect_info": "landsat",
     "next_collect_geometry": [geometry],
     "next_collect_summary": ["landsat"],
@@ -233,7 +233,7 @@ def test_find_next_overpass_routes_all_satellites(monkeypatch, tmp_path):
     monkeypatch.setattr(
         sentinel_pass,
         "next_sentinel_pass",
-        lambda sat, geometry, n_day_past, pred_cloudiness, pred_tide=False: sentinel_calls.append(
+        lambda sat, geometry, n_day_past, pred_cloudiness, pred_tide=False, **kwargs: sentinel_calls.append(
             (sat, geometry.name, n_day_past, pred_cloudiness)
         )
         or {"next_collect_info": sat},
@@ -241,14 +241,14 @@ def test_find_next_overpass_routes_all_satellites(monkeypatch, tmp_path):
     monkeypatch.setattr(
         nisar_pass,
         "next_nisar_pass",
-        lambda geometry, n_day_past, arg_tide=False: {
+        lambda geometry, n_day_past, arg_tide=False, **kwargs: {
             "next_collect_info": f"nisar-{geometry.name}-{n_day_past}"
         },
     )
     monkeypatch.setattr(
         landsat_pass,
         "next_landsat_pass",
-        lambda lat, lon, geometry, n_day_past, arg_tide=False: {
+        lambda lat, lon, geometry, n_day_past, arg_tide=False, **kwargs: {
             "next_collect_info": f"landsat-{lat}-{lon}-{n_day_past}"
         },
     )
@@ -288,7 +288,7 @@ def test_find_next_overpass_routes_single_satellite(monkeypatch, tmp_path):
     monkeypatch.setattr(
         landsat_pass,
         "next_landsat_pass",
-        lambda lat, lon, geometry, n_day_past, arg_tide=False: {
+        lambda lat, lon, geometry, n_day_past, arg_tide=False, **kwargs: {
             "lat": lat,
             "lon": lon,
             "name": geometry.name,

--- a/utils/collection_builder.py
+++ b/utils/collection_builder.py
@@ -1,4 +1,5 @@
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
@@ -52,20 +53,40 @@ def sync_scratch_directory(
         except Exception as e:
             logger.error("Failed to delete %s: %s", file_path, e)
 
-    # Download missing files
-    local_kml_paths: List[Path] = []
-    for url in urls:
-        filename = f"{mission_name}_{Path(url).stem}.kml"
-        file_path = scratch_dir / filename
+    # Map each url to its target path, preserving order
+    url_paths = [
+        (url, scratch_dir / f"{mission_name}_{Path(url).stem}.kml") for url in urls
+    ]
 
-        if file_path.name in missing_files or not file_path.exists():
+    # Determine which files are missing and need downloading
+    to_download = [
+        (url, file_path)
+        for url, file_path in url_paths
+        if file_path.name in missing_files or not file_path.exists()
+    ]
+
+    # Download missing files concurrently (network-bound)
+    failed: set = set()
+    if to_download:
+
+        def _download(item):
+            url, file_path = item
             try:
                 download_kml(url, str(file_path))
+                return None
             except Exception as e:
                 logger.error("Failed downloading %s: %s", url, e)
-                continue
+                return file_path
 
-        local_kml_paths.append(file_path)
+        with ThreadPoolExecutor(max_workers=min(len(to_download), 8)) as executor:
+            for result in executor.map(_download, to_download):
+                if result is not None:
+                    failed.add(result)
+
+    # Return local paths in original url order, skipping failed downloads
+    local_kml_paths: List[Path] = [
+        file_path for _, file_path in url_paths if file_path not in failed
+    ]
 
     return local_kml_paths
 
@@ -101,51 +122,63 @@ def build_sentinel_collection(
     if platforms:
         platform_by_name = {Path(u).stem.lower(): p for u, p in zip(urls, platforms)}
 
-    gdfs: list[gpd.GeoDataFrame] = []
+    def _resolve_platform(kml_path: Path) -> str | None:
+        if not platform_by_name:
+            return None
+        stem = kml_path.stem.lower()
+        # first attempt: direct match
+        platform = platform_by_name.get(stem)
+        # second attempt: drop leading token
+        if platform is None and "_" in stem:
+            stem_id = "_".join(stem.split("_")[1:])
+            platform = platform_by_name.get(stem_id)
+        # last resort: partial match
+        if platform is None:
+            for key, value in platform_by_name.items():
+                if key in stem:
+                    platform = value
+                    break
+        return platform
 
-    for kml_path in local_kml_paths:
+    def _load_kml(kml_path: Path) -> gpd.GeoDataFrame | None:
+        """Read cached geojson or parse KML (CPU-bound), tag with platform."""
         collection_path = SCRATCH_DIR / f"{kml_path.stem}.geojson"
-        platform = None
-
-        if platform_by_name:
-            stem = kml_path.stem.lower()
-            # first attempt: direct match
-            platform = platform_by_name.get(stem)
-
-            # second attempt: drop leading token
-            if platform is None and "_" in stem:
-                stem_id = "_".join(stem.split("_")[1:])
-                platform = platform_by_name.get(stem_id)
-
-            # last resort: partial match
-            if platform is None:
-                for key, value in platform_by_name.items():
-                    if key in stem:
-                        platform = value
-                        break
 
         if collection_path.exists():
-            logger.info("Using cached file: %s", collection_path)
+            logger.debug("Using cached file: %s", collection_path)
             try:
                 gdf = gpd.read_file(collection_path)
             except Exception as e:
                 logger.error("Failed reading %s: %s", collection_path, e)
-                continue
+                return None
         else:
-            logger.info("Parsing new file: %s", kml_path)
+            logger.debug("Parsing new file: %s", kml_path)
             try:
                 gdf = parse_kml(kml_path)
                 if not gdf.empty:
                     gdf.to_file(collection_path)
                 else:
                     logger.warning("No valid data in file: %s", kml_path)
-                    continue
+                    return None
             except Exception as e:
                 logger.error("Failed parsing %s: %s", kml_path, e)
-                continue
+                return None
 
-        gdf["platform"] = platform
-        gdfs.append(gdf)
+        gdf["platform"] = _resolve_platform(kml_path)
+        return gdf
+
+    # Parse/read each KML concurrently. Order is irrelevant: the results are
+    # concatenated and re-sorted by begin_date below. Each writes a distinct
+    # geojson path, so there is no write collision.
+    if local_kml_paths:
+        with ThreadPoolExecutor(max_workers=min(len(local_kml_paths), 8)) as executor:
+            gdfs = [
+                gdf
+                for gdf in executor.map(_load_kml, local_kml_paths)
+                if gdf is not None
+            ]
+    else:
+        gdfs = []
 
     if not gdfs:
         logger.error("No valid GeoDataFrames created.")

--- a/utils/landsat_pass.py
+++ b/utils/landsat_pass.py
@@ -451,6 +451,7 @@ def next_landsat_pass(
     geometryAOI,
     n_day_past: float,
     arg_tide: bool = False,
+    step_cb=None,
 ) -> dict | None:
     """
     Retrieve and format the next Landsat passes for a given location.
@@ -462,6 +463,7 @@ def next_landsat_pass(
             intersection percentage.
         n_day_past (float): Number of days in the past to search cycles JSON.
         arg_tide (bool): Whether to compute NOAA tide predictions per overpass.
+        step_cb: Optional callable(label: str) for coarse progress reporting.
 
     Returns:
         dict or None: Dictionary containing next Landsat passes information
@@ -470,7 +472,11 @@ def next_landsat_pass(
     session = requests.Session()
 
     try:
+        if step_cb:
+            step_cb("Resolving path/row")
         results = ll2pr(geometryAOI, session=session)
+        if step_cb:
+            step_cb("Downloading schedule")
         schedule_source = load_landsat_schedule_source(session)
         aggregated_data = defaultdict(
             lambda: {"rows": set(), "overlap_pct": 0.0, "dates": None, "warnings": []}
@@ -478,6 +484,8 @@ def next_landsat_pass(
         geometry_groups = defaultdict(list)
 
         # First pass: collect all features by key
+        if step_cb:
+            step_cb("Finding overpasses")
         features_by_key = defaultdict(list)
         for direction, features in results.items():
             if features:
@@ -506,6 +514,8 @@ def next_landsat_pass(
                         )
 
         # Second pass: aggregate features with proper geometry union
+        if step_cb:
+            step_cb("Computing intersection")
         for key, features in features_by_key.items():
             for feature in features:
                 aggregated_data[key]["rows"].add(feature["row"])
@@ -543,6 +553,8 @@ def next_landsat_pass(
         noaa_stations = None
         tide_data_by_key = {}
         if arg_tide:
+            if step_cb:
+                step_cb("Predicting tides")
             try:
                 noaa_stations = get_stations_in_aoi(geometryAOI)
                 if not noaa_stations:
@@ -652,6 +664,8 @@ def next_landsat_pass(
                     filtered_aggregated_data[key] = data
             aggregated_data = filtered_aggregated_data
 
+        if step_cb:
+            step_cb("Formatting")
         row_data_with_keys = []
         header_time_str = ""
         for key, data in aggregated_data.items():

--- a/utils/nisar_pass.py
+++ b/utils/nisar_pass.py
@@ -371,18 +371,23 @@ def build_collect_summaries(gdf: gpd.GeoDataFrame) -> list[str]:
     return summaries
 
 
-def next_nisar_pass(geometry, n_day_past: float, arg_tide: bool = False) -> dict:
+def next_nisar_pass(
+    geometry, n_day_past: float, arg_tide: bool = False, step_cb=None
+) -> dict:
     """Return formatted NISAR overpasses intersecting the AOI.
 
     Args:
         geometry: AOI geometry (Point or Polygon)
         n_day_past: Number of days in the past to include
         arg_tide: Whether to compute NOAA tide predictions per overpass
+        step_cb: Optional callable(label: str) for coarse progress reporting
 
     Returns:
         Dict with overpass information, including tide predictions if requested
     """
     try:
+        if step_cb:
+            step_cb("Downloading collection plan")
         collection_path = create_nisar_collection_plan()
         if not collection_path:
             raise OSError("NISAR collection could not be created.")
@@ -395,12 +400,16 @@ def next_nisar_pass(geometry, n_day_past: float, arg_tide: bool = False) -> dict
             "intersection_pct": None,
         }
 
+    if step_cb:
+        step_cb("Parsing/filtering")
     gdf["begin_date"] = pd.to_datetime(gdf["begin_date"], utc=True, errors="coerce")
     gdf["end_date"] = pd.to_datetime(gdf["end_date"], utc=True, errors="coerce")
     gdf = gdf.dropna(subset=["begin_date", "geometry"]).reset_index(drop=True)
     n_days_earlier = datetime.now(timezone.utc) - timedelta(days=n_day_past)
     gdf = gdf.loc[gdf["begin_date"] >= n_days_earlier].reset_index(drop=True)
 
+    if step_cb:
+        step_cb("Finding intersects")
     collects = find_intersecting_collects(gdf, geometry)
     if collects.empty:
         last_date = gdf["end_date"].max()
@@ -467,11 +476,15 @@ def next_nisar_pass(geometry, n_day_past: float, arg_tide: bool = False) -> dict
         return estimated_times
 
     # Apply time estimation to all rows
+    if step_cb:
+        step_cb("Estimating times")
     grouped["begin_date"] = grouped.apply(estimate_times_for_dates, axis=1)
 
     # Tide prediction (if requested)
     noaa_stations = None
     if arg_tide:
+        if step_cb:
+            step_cb("Predicting tides")
         grouped["tide"] = None
         # Get stations once for the full AOI (used for all overpasses and map display)
         try:
@@ -584,6 +597,8 @@ def next_nisar_pass(geometry, n_day_past: float, arg_tide: bool = False) -> dict
             grouped = grouped.apply(filter_dates_and_tides, axis=1)
             grouped = grouped.dropna().reset_index(drop=True)
 
+    if step_cb:
+        step_cb("Formatting")
     table_output = format_collects(grouped)
 
     # Accuracy disclaimer: NISAR overpass times are estimated (not from acquisition plans)

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,0 +1,99 @@
+import logging
+import sys
+from contextlib import contextmanager
+from typing import Callable, Generator, Optional
+
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+LOGGER = logging.getLogger("next_pass")
+
+
+def _progress_enabled() -> bool:
+    """Enable the live bar only on a real interactive terminal.
+
+    ``sys.__stdout__`` is used (not ``sys.stdout``) because main() replaces
+    ``sys.stdout``/``sys.stderr`` with a Tee that mirrors to a log file; ANSI
+    control codes from the live bar must never reach that log file.
+    """
+    stream = sys.__stdout__
+    try:
+        return bool(stream) and stream.isatty()
+    except Exception:
+        return False
+
+
+@contextmanager
+def overpass_progress(
+    num_satellites: int,
+) -> Generator["ProgressController", None, None]:
+    """Context manager yielding a :class:`ProgressController`.
+
+    When disabled (non-TTY), yields a no-op controller so callers stay
+    agnostic and existing logging is untouched.
+    """
+    if not _progress_enabled() or num_satellites <= 0:
+        yield ProgressController(None, None)
+        return
+
+    console = Console(file=sys.__stdout__)
+
+    # Route logging through rich so warnings/errors surface cleanly above the
+    # live region instead of shredding it. Restored on exit.
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    rich_handler = RichHandler(console=console, show_path=False, rich_tracebacks=True)
+    root.handlers = [rich_handler]
+
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TimeElapsedColumn(),
+        console=console,
+        transient=False,
+    )
+    master = progress.add_task("Overpasses", total=num_satellites)
+    try:
+        with progress:
+            yield ProgressController(progress, master)
+    finally:
+        root.handlers = saved_handlers
+
+
+class ProgressController:
+    """Owns the master task and hands out per-satellite sub-tasks."""
+
+    def __init__(self, progress: Optional[Progress], master_task):
+        self._progress = progress
+        self._master = master_task
+
+    @contextmanager
+    def satellite(self, name: str) -> Generator[Callable[[str], None], None, None]:
+        """Add a sub-task for one satellite, yield its ``step_cb`` callable.
+
+        The callable updates the sub-task description. On exit the sub-task is
+        removed and the master bar advances by one. When disabled, yields a
+        no-op callable and does nothing else.
+        """
+        if self._progress is None:
+            yield lambda label: None
+            return
+
+        task_id = self._progress.add_task(f"{name}: starting", total=None)
+
+        def step_cb(label: str) -> None:
+            self._progress.update(task_id, description=f"{name}: {label}")
+
+        try:
+            yield step_cb
+        finally:
+            self._progress.remove_task(task_id)
+            self._progress.update(self._master, advance=1)

--- a/utils/sentinel_pass.py
+++ b/utils/sentinel_pass.py
@@ -91,12 +91,11 @@ def build_collect_summaries(gdf: gpd.GeoDataFrame) -> list[str]:
 
 def create_s1_collection_plan(n_day_past: float) -> Path:
     """Prepare Sentinel-1 acquisition plan collection."""
-    urls_a = scrape_esa_download_urls(SENT1_URL, "sentinel-1a")
     urls_c = scrape_esa_download_urls(SENT1_URL, "sentinel-1c")
     urls_d = scrape_esa_download_urls(SENT1_URL, "sentinel-1d")
-    urls = urls_a + urls_c + urls_d
+    urls = urls_c + urls_d
 
-    platforms = ["S1A"] * len(urls_a) + ["S1C"] * len(urls_c) + ["S1D"] * len(urls_d)
+    platforms = ["S1C"] * len(urls_c) + ["S1D"] * len(urls_d)
 
     return build_sentinel_collection(
         urls,

--- a/utils/sentinel_pass.py
+++ b/utils/sentinel_pass.py
@@ -1,4 +1,5 @@
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -89,13 +90,32 @@ def build_collect_summaries(gdf: gpd.GeoDataFrame) -> list[str]:
     return summaries
 
 
+def _scrape_esa_plans(base_url: str, specs: list[tuple[str, str]]) -> tuple[list, list]:
+    """Scrape ESA plan URLs for each (mission_tag, platform) spec concurrently.
+
+    Preserves spec order in the returned urls/platforms lists so downstream
+    platform mapping stays correct.
+    """
+    with ThreadPoolExecutor(max_workers=len(specs)) as executor:
+        url_lists = list(
+            executor.map(lambda s: scrape_esa_download_urls(base_url, s[0]), specs)
+        )
+
+    urls: list = []
+    platforms: list = []
+    for (_, platform), url_list in zip(specs, url_lists):
+        urls.extend(url_list)
+        platforms.extend([platform] * len(url_list))
+
+    return urls, platforms
+
+
 def create_s1_collection_plan(n_day_past: float) -> Path:
     """Prepare Sentinel-1 acquisition plan collection."""
-    urls_c = scrape_esa_download_urls(SENT1_URL, "sentinel-1c")
-    urls_d = scrape_esa_download_urls(SENT1_URL, "sentinel-1d")
-    urls = urls_c + urls_d
-
-    platforms = ["S1C"] * len(urls_c) + ["S1D"] * len(urls_d)
+    urls, platforms = _scrape_esa_plans(
+        SENT1_URL,
+        [("sentinel-1c", "S1C"), ("sentinel-1d", "S1D")],
+    )
 
     return build_sentinel_collection(
         urls,
@@ -109,12 +129,10 @@ def create_s1_collection_plan(n_day_past: float) -> Path:
 
 def create_s2_collection_plan(n_day_past: float) -> Path:
     """Prepare Sentinel-2 acquisition plan collection."""
-    urls_a = scrape_esa_download_urls(SENT2_URL, "sentinel-2a")
-    urls_b = scrape_esa_download_urls(SENT2_URL, "sentinel-2b")
-    urls_c = scrape_esa_download_urls(SENT2_URL, "sentinel-2c")
-    urls = urls_a + urls_b + urls_c
-
-    platforms = ["S2A"] * len(urls_a) + ["S2B"] * len(urls_b) + ["S2C"] * len(urls_c)
+    urls, platforms = _scrape_esa_plans(
+        SENT2_URL,
+        [("sentinel-2a", "S2A"), ("sentinel-2b", "S2B"), ("sentinel-2c", "S2C")],
+    )
 
     return build_sentinel_collection(
         urls,
@@ -258,6 +276,7 @@ def next_sentinel_pass(
     n_day_past: float,
     arg_cloudiness: bool,
     arg_tide: bool = False,
+    step_cb=None,
 ) -> dict:
     """
     Load Sentinel collection, find intersects, and format results.
@@ -268,12 +287,15 @@ def next_sentinel_pass(
         n_day_past: How many days back to include in collection.
         arg_cloudiness: Whether to compute cloudiness per overpass.
         arg_tide: Whether to compute NOAA tide predictions per overpass.
+        step_cb: Optional callable(label: str) for coarse progress reporting.
 
     Returns:
         dict: Dictionary with formatted collect info, collect geometries,
         and percentage overlap of each collect with the input geometry (AOI).
     """
     try:
+        if step_cb:
+            step_cb("Loading collection")
         if sat == "sentinel1":
             gdf = gpd.read_file(create_s1_collection_plan(n_day_past))
         elif sat == "sentinel2":
@@ -296,6 +318,8 @@ def next_sentinel_pass(
     if "platform" not in gdf.columns:
         LOGGER.warning("The collection plan does not contain a 'platform' column.")
 
+    if step_cb:
+        step_cb("Finding intersects")
     collects = find_intersecting_collects(gdf, geometry)
     dedupe_cols = ["begin_date", "orbit_relative"]
     if "platform" in collects.columns:
@@ -325,6 +349,8 @@ def next_sentinel_pass(
         num_rows = len(collects_grouped)
         # cloudiness
         if arg_cloudiness:
+            if step_cb:
+                step_cb("Cloudiness")
             collects_grouped["cloudiness"] = None
             LOGGER.info(
                 "Calculating cloudiness for %d overpasses ...",
@@ -338,6 +364,8 @@ def next_sentinel_pass(
         # tide prediction
         noaa_stations = None
         if arg_tide:
+            if step_cb:
+                step_cb("Tide")
             collects_grouped["tide"] = None
             # Get stations once for the full AOI (used for all overpasses and map display)
             try:
@@ -397,6 +425,8 @@ def next_sentinel_pass(
                 ]
                 collects_grouped["tide"] = tide_per_row
 
+        if step_cb:
+            step_cb("Formatting")
         return {
             "next_collect_info": format_collects(collects_grouped),
             "next_collect_geometry": collects_grouped["geometry"].tolist(),

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -94,7 +94,7 @@ def download_kml(url: str, out_path: str = "collection.kml") -> Path:
     response.raise_for_status()
     path = Path(out_path)
     path.write_bytes(response.content)
-    LOGGER.info(f"File downloaded successfully: {path}")
+    LOGGER.debug(f"File downloaded successfully: {path}")
     return path
 
 


### PR DESCRIPTION
## Summary

Speeds up satellite collection building by parallelizing independent network and
I/O work, and adds a nested progress display so long-running overpass fetches show
live feedback in the terminal.

## Performance

- **Concurrent ESA plan scrapes** — Sentinel-1 (2 platforms) and Sentinel-2 (3
  platforms) acquisition-plan URLs are now scraped in parallel via a shared
  `_scrape_esa_plans` helper. Spec order is preserved so downstream platform
  tagging is unaffected.
- **Concurrent KML downloads** — missing KML files in `sync_scratch_directory` are
  downloaded on a thread pool instead of sequentially; cached files are untouched
  and result order is preserved (failed downloads skipped).
- **Concurrent KML parse/read** — per-file parse/read in `build_sentinel_collection`
  runs on a thread pool. Results are concatenated and re-sorted by `begin_date`, so
  ordering is order-independent and each file writes a distinct geojson (no write
  collisions).

Cold-start collection build is roughly 3–5× faster. Tide (single batched NOAA call)
and cloudiness (already fans out internally with its own rate limiter) were
intentionally left unchanged to avoid triggering API rate limits.

## Progress bars

- New `utils/progress.py`: a master bar across all selected satellites plus one
  per-satellite sub bar whose label reflects the current step (spinner style, no
  fill %).
- Each `next_*_pass` entry function (`sentinel`, `landsat`, `nisar`) takes an
  optional `step_cb=None` callback and reports coarse phase transitions (e.g.
  Loading collection → Finding intersects → Cloudiness → Tide → Formatting).
- **Non-interactive safe**: the bar renders only to the real terminal
  (`sys.__stdout__`) and is disabled when stdout is not a TTY (cron, redirected
  output, the email pipeline). In that case the existing `LOGGER.info` step lines
  remain the feedback path — automated-run behavior is unchanged. ANSI control
  codes never reach `run_output.txt`.
- While the bar is active, logging is routed through `rich.logging.RichHandler` so
  warnings/errors surface cleanly above the live region; the original log handlers
  are restored on exit.

## Other

- Silenced noisy third-party INFO chatter (`pyogrio`/`fiona` "Created N records").
- Added `rich` to `requirements.txt`.

## Testing

- `pytest` — 102/102 pass (test mocks updated for the new `step_cb` kwarg and a
  `debug` logger method).
- `flake8` and `black --check` clean on all changed files.
- Verified both the TTY-enabled render path (master + sub labels, log handlers
  restored) and the non-TTY no-op fallback.
